### PR TITLE
fix: crash when no result and undefined error with autocomplete

### DIFF
--- a/extern_js/pull_autocomplete.js
+++ b/extern_js/pull_autocomplete.js
@@ -35,12 +35,16 @@ function pull(query, hl, expIds, cp) {
                 result = parser.parse(result)
                 let send = "window.google.ac.h([\"" + query + "\",[";
                 try {
-                    result.toplevel.CompleteSuggestion.forEach(( content, i ) => {
-                        // let now = "[\"" + content.suggestion.data + "\",\"\",\"" + i + "\"],"
-                        // let now = "[\"" + content.suggestion.data + "\",\"" + content.suggestion.data + "\",\"\",\"\"],"
-                        let now = "[\"" + content.suggestion.data + "\",[0]],"
-                        send = send + now
-                    })
+                    const suggestions = result?.toplevel?.CompleteSuggestion;
+
+                    if (Array.isArray(suggestions)) {
+                        suggestions.forEach((content, i) => {
+                            // let now = "[\"" + content.suggestion.data + "\",\"\",\"" + i + "\"],"
+                            // let now = "[\"" + content.suggestion.data + "\",\"" + content.suggestion.data + "\",\"\",\"\"],"
+                            let now = "[\"" + content.suggestion.data + "\",[0]],"
+                            send = send + now
+                        })
+                    }
                     send = send.replace(/(.*),/, "$1") + `] , {
                         "j":"${expIds}",
                         "client": "hp",

--- a/index.js
+++ b/index.js
@@ -1170,6 +1170,7 @@ app.get('/search', async (req, res) => {
                 return
             }
             res.send(repl)
+            return
         }
         
         if (only_old == true) {


### PR DESCRIPTION
This pull request fixes an issue when no search results are found it will crash. and also `TypeError: Cannot read properties of undefined (reading 'forEach')` error when auto-complete (refs pap-git/gs2009#5, refs https://github.com/pap-git/gs2009/issues/16)

## Error gs2009 produced when no search results are found:
<img width="1130" height="788" alt="image" src="https://github.com/user-attachments/assets/4b5208a6-ba43-4671-96de-651737843586" />
