### PR TITLE
fix: leftover page selector and search box when no results are found

### DIFF
--- a/html/en/search.html
+++ b/html/en/search.html
@@ -152,6 +152,29 @@ google.y={};google.x=function(e,g){google.y[e.id]=[e,g];return false};window.gba
           <div style="height:1px;line-height:0"></div>
           <div style="text-align:center;margin-top:1.4em" class="clr">
           <div id="bsf" style="padding:1.8em 0;margin-top:0">
+            <div id="fixMe">
+              <!--
+                okay, so the purpose of this is for 
+                showing when the search results return
+                nothing.
+                
+                this is a really bad implementation
+                please fix this with a better impl, ty
+
+                see index.js:1162 for more info
+              -->
+              <p>
+                <a href="/">Google&nbsp;Home</a>
+                - 
+                <a href="http://www.google.com/intl/en/ads/">Advertising&nbsp;Programs</a>
+                - 
+                <a href="http://www.google.com/services/">Business Solutions</a>
+                - 
+                <a href="http://www.google.com/intl/en/privacy.html">Privacy</a>
+                - 
+                <a href="/intl/ja/about.html">About Google</a>
+              </p>
+            </div>
             <form method="get" action="/search">
               <div>
                 <input type="text" name="q" size="41" maxlength="2048" value="query" title="Search">

--- a/html/ja/search.html
+++ b/html/ja/search.html
@@ -197,6 +197,29 @@ google.y={};google.x=function(e,g){google.y[e.id]=[e,g];return false};window.gba
           <div style="height:1px;line-height:0"></div>
           <div style="text-align:center;margin-top:1.4em" class="clr">
           <div id="bsf" style="padding:1.8em 0;margin-top:0">
+            <div id="fixMe">
+              <!--
+                okay, so the purpose of this is for 
+                showing when the search results return
+                nothing.
+                
+                this is a really bad implementation
+                please fix this with a better impl, ty
+
+                see index.js:1162 for more info
+              -->
+              <p>
+                <a href="/">Google&nbsp;ホーム</a>
+                - 
+                <a href="http://www.google.com/intl/en/ads/">広告掲載</a>
+                - 
+                <a href="http://www.google.com/services/">ビジネス ソリューション</a>
+                - 
+                <a href="http://www.google.com/intl/en/privacy.html">プライバシー</a>
+                - 
+                <a href="/intl/ja/about.html">Google について</a>
+              </p>
+            </div>
             <form method="get" action="/search">
               <div>
                 <input type="text" name="q" size="41" maxlength="2048" value="query" title="Search">

--- a/html/th/search.html
+++ b/html/th/search.html
@@ -159,6 +159,29 @@ google.y={};google.x=function(e,g){google.y[e.id]=[e,g];return false};window.gba
           <div style="height:1px;line-height:0"></div>
           <div style="text-align:center;margin-top:1.4em" class="clr">
           <div id="bsf" style="padding:1.8em 0;margin-top:0">
+            <div id="fixMe">
+              <!--
+                okay, so the purpose of this is for 
+                showing when the search results return
+                nothing.
+                
+                this is a really bad implementation
+                please fix this with a better impl, ty
+
+                see index.js:1162 for more info
+              -->
+              <p>
+                <a href="/">Google&nbsp;Home</a>
+                - 
+                <a href="http://www.google.com/intl/en/ads/">โปรแกรมโฆษณา</a>
+                - 
+                <a href="http://www.google.com/services/">ทางออกทางธุรกิจ</a>
+                - 
+                <a href="http://www.google.com/intl/en/privacy.html">ความเป็นส่วนตัว</a>
+                - 
+                <a href="/intl/ja/about.html">เกี่ยวกับ Google ทั้งหมด</a>
+              </p>
+            </div>
             <form method="get" action="/search">
               <div>
                 <input type="text" name="q" size="41" maxlength="2048" value="query" title="ค้นหา">

--- a/index.js
+++ b/index.js
@@ -1156,7 +1156,8 @@ app.get('/search', async (req, res) => {
 
             repl = repl.replace(/topItem/g, ext_t_s_nf);
 
-            repl = repl.replace(/<p>(\s+.+){1,2}\s+<div id="res" class="med">/, '<p><br></p></div><div id="res" class="med">')
+            // should be good enough to catch no result
+            repl = repl.replace(/(<br clear="all"\/>\s*)?<table id="nav"[\s\S]*?<\/table>/, "")
 
             if (only_old == true) {
                 repl = repl.replace(/query/g, actualq)

--- a/index.js
+++ b/index.js
@@ -1159,6 +1159,13 @@ app.get('/search', async (req, res) => {
             // should be good enough to catch no result
             repl = repl.replace(/(<br clear="all"\/>\s*)?<table id="nav"[\s\S]*?<\/table>/, "")
 
+            // based on https://web.archive.org/web/20090126005121/http://google.com:80/Search%20results=Sexy
+            // the "Google Home" and etc links should be inside bsf.
+            // i don't know how to implement this properly
+            repl = repl.replace(/(<div id="fixMe">[\s\S]*?<\/div>)[\s\S]*?<\/div>\s*<p>[\s\S]*?<\/p>/, '$1\n          </div>')
+            repl = repl.replace(/(<div id="bsf" style=")padding:1\.8em 0;/, '$1')
+            repl = repl.replace(/<p>(\s+.+){1,2}\s+<div id="res" class="med">/, '<p><br></p></div><div id="res" class="med">')
+
             if (only_old == true) {
                 repl = repl.replace(/query/g, actualq)
             } else {
@@ -1173,6 +1180,9 @@ app.get('/search', async (req, res) => {
             res.send(repl)
             return
         }
+
+        // remove `fixMe` if the result is actually there
+        repl = repl.replace(/<div id="fixMe">[\s\S]*?<\/div>\s*/, "")
         
         if (only_old == true) {
             repl = repl.replace(/query/g, actualq)


### PR DESCRIPTION
This pull request fixes the no results page still showing the page selector even tho there is no result. (refs pap-git/gs2009#15).

And implementing the footer according to [this archived webpage](https://web.archive.org/web/20090126005121/http://google.com:80/Search%20results=Sexy).

### Note:
The implementation is really bad on this one, so please review before merging

## Before:

<img width="1284" height="789" alt="image" src="https://github.com/user-attachments/assets/e96f229c-a464-47de-a986-dc7ffbb8c247" />

## After:

<img width="1284" height="789" alt="image" src="https://github.com/user-attachments/assets/4d7d168c-8fb8-4134-a38d-50b1d999a667" />